### PR TITLE
Provide image data range to TF `structural_similarity()`

### DIFF
--- a/ganrectf/utils.py
+++ b/ganrectf/utils.py
@@ -192,7 +192,8 @@ class RECONmonitor:
                 
                 
             # img_diff = np.abs(prj_rec - self.img_input)
-            ssim_index, ssim_map = ssim(prj_rec, self.img_input, full=True)
+            img_range = self.img_input.max() - self.img_input.min()
+            ssim_index, ssim_map = ssim(prj_rec, self.img_input, full=True, data_range=img_range)
             self.tx1.set_text("SSIM map of " + self.plot_txt + " for iteration {0}".format(self.epoch))
             vmax = np.max(ssim_map)
             vmin = np.min(ssim_map)


### PR DESCRIPTION
When I run the [holography_tf notebook](https://github.com/XYangXRay/ganrec/blob/main/examples/holography_tf.ipynb) the reconstruction fails with the error below.

I am using:
* python 3.11.9
* tensorflow 2.16.1

Using the recommended fix from the error message resolved this issue.

---------------------------------------------------------------------------
```
File ~/conda_envs/ganrec/lib/python3.11/site-packages/skimage/metrics/_structural_similarity.py:204, in structural_similarity(im1, im2, win_size, gradient, data_range, channel_axis, gaussian_weights, full, **kwargs)
    200 if data_range is None:
    201     if np.issubdtype(im1.dtype, np.floating) or np.issubdtype(
    202         im2.dtype, np.floating
    203     ):
--> 204         raise ValueError(
    205             'Since image dtype is floating point, you must specify '
    206             'the data_range parameter. Please read the documentation '
    207             'carefully (including the note). It is recommended that '
    208             'you always specify the data_range anyway.'
    209         )
```